### PR TITLE
install python version for which tensorflow exists

### DIFF
--- a/1. Setup.ipynb
+++ b/1. Setup.ipynb
@@ -96,7 +96,7 @@
     "\n",
     "Install Python (in the current enviornment):\n",
     "\n",
-    "`conda install -c anaconda python`"
+    "`conda install -c anaconda python=3.7`"
    ]
   },
   {


### PR DESCRIPTION
At least on macOS, the latest anaconda installs python3.8, however tensorflow package doesn't exist for that python version (yet), so this change installs the latest compatible version of python.